### PR TITLE
Setup for `0.2.0` release.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-0.2.0 (unreleased)
+0.2.0 (2023-03-21)
 ------------------
 
 - Add documentation to package. [#8]


### PR DESCRIPTION
There is a small issue with the `0.1.0` release of this package on PyPi noted by @mwcraig in https://github.com/conda-forge/asdf-astropy-feedstock/pull/6#issuecomment-1477880268. This is blocking the release of `asdf-astropy 0.4.0` on `conda-forge`.

Thus a new release of `asdf-coordinates-schemas` should be made, and we might as well release with all the minor changes and clean-ups which have been merged since the `0.1.0` release.