### PR TITLE
Add asdf-astropy as test dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.3.0 (unreleased)
+------------------
+
+- Add ``asdf-astropy`` as a test dependency. [#34]
+
 0.2.0 (2023-03-21)
 ------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ docs = [
 ]
 test = [
     'pytest',
+    'asdf-astropy >= 0.2.0'
 ]
 
 [project.urls]


### PR DESCRIPTION
Locally, when running the tests in a brand new environment I am seeing failures due to the deprecation warnings originating in the deprecation of `astropy.io.asdf.misc` in favor of `asdf-astropy` this PR adds `asdf-astropy` as a dependency for testing purposes.