### PR TITLE
Update schemas for ASDF standard 1.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - name: Python 3.12 Schema validation tests
+            python-version: '3.12'
+            os: ubuntu-latest
+            toxenv: py312
+
           - name: Python 3.11 Schema validation tests
             python-version: '3.11'
             os: ubuntu-latest

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 
 - Add ``asdf-astropy`` as a test dependency. [#34]
 - Drop official support for Python 3.8 [#42]
+- Update schemas for ASDF standard 1.6.0 [#55]
 
 0.2.0 (2023-03-21)
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 ]
 dependencies = [
   'asdf >= 2.12.1',
+  'asdf-standard >= 1.1.0',
 ]
 dynamic = ['version']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ classifiers = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Science/Research',
     'Topic :: Scientific/Engineering :: Astronomy',

--- a/resources/manifests/coordinates-1.1.0.yaml
+++ b/resources/manifests/coordinates-1.1.0.yaml
@@ -1,0 +1,73 @@
+id: asdf://asdf-format.org/astronomy/coordinates/manifests/coordinates-1.1.0
+extension_uri: asdf://asdf-format.org/astronomy/coordinates/extensions/coordinates-1.1.0
+title: Coordinates extension 1.1.0
+description: |-
+  A set of tags for serializing coordinates.
+tags:
+- tag_uri: tag:astropy.org:astropy/coordinates/angle-1.1.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/angle-1.1.0
+  title: Represents an Angle.
+  description: |-
+    This object represents a subtype of Quantity which has units equivalent to radians or degrees.
+- tag_uri: tag:astropy.org:astropy/coordinates/earthlocation-1.1.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/earthlocation-1.1.0
+  title: Represents EarthLocation objects from astropy.
+  description: |-
+    Location on the Earth.
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/baseframe-1.1.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/baseframe-1.1.0
+  title: Represents a coordinate frame object from astropy
+  description: |-
+    This schema is designed to be extended by other schemas to restrict the
+    allowable frame_attributes.
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/cirs-1.1.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/cirs-1.1.0
+  title: Represents a CIRS coordinate object from astropy
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/fk4-1.1.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/fk4-1.1.0
+  title: Represents a FK4 coordinate object from astropy
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/fk4noeterms-1.1.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/fk4noeterms-1.1.0
+  title: Represents a FK4NoETerms coordinate object from astropy
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/fk5-1.1.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/fk5-1.1.0
+  title: Represents a FK5 coordinate object from astropy
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/galactic-1.1.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/galactic-1.1.0
+  title: Represents an Galactic coordinate object from astropy.
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/galactocentric-1.1.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/galactocentric-1.1.0
+  title: Represents an galactocentric coordinate object from astropy
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/gcrs-1.1.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/gcrs-1.1.0
+  title: Represents a GCRS coordinate object from astropy
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/icrs-1.2.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/icrs-1.1.0
+  title: Represents an ICRS coordinate object from astropy.
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/itrs-1.1.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/itrs-1.1.0
+  title: Represents a ITRS coordinate object from astropy
+- tag_uri: tag:astropy.org:astropy/coordinates/frames/precessedgeocentric-1.1.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/frames/precessedgeocentric-1.1.0
+  title: Represents a PrecessedGeocentric coordinate object from astropy
+- tag_uri: tag:astropy.org:astropy/coordinates/latitude-1.1.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/latitude-1.1.0
+  title: Represents latitude-like angles.
+  description: |-
+    Represents latitude-like angle(s) which must be in the range -90 to +90 deg.
+- tag_uri: tag:astropy.org:astropy/coordinates/longitude-1.1.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/longitude-1.1.0
+  title: Represents longitude-like angles.
+  description: |-
+    Longitude-like angle(s) which are wrapped within a contiguous 360 degree range.
+- tag_uri: tag:astropy.org:astropy/coordinates/representation-1.1.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/representation-1.1.0
+  title: Representation of points or differentials in two or three dimensional space.
+  description: |-
+    Representation of points or differentials in two or three dimensional space.
+- tag_uri: tag:astropy.org:astropy/coordinates/skycoord-1.0.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/skycoord-1.0.0
+  title: Represents a SkyCoord object from astropy
+- tag_uri: tag:astropy.org:astropy/coordinates/spectralcoord-1.1.0
+  schema_uri: http://astropy.org/schemas/astropy/coordinates/spectralcoord-1.1.0
+  title: Represents a SpectralCoord object from astropy

--- a/resources/schemas/angle-1.1.0.yaml
+++ b/resources/schemas/angle-1.1.0.yaml
@@ -1,0 +1,37 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/angle-1.1.0"
+
+title: |
+  Represents an Angle.
+
+# TODO: Is there any restriction on the range of values?  The next
+# version of the schema should make this explicit.
+description:
+  This object represents a subtype of Quantity which has units equivalent to
+  radians or degrees.
+
+examples:
+  -
+    - An Angle object in Degrees
+    - asdf-standard-1.6.0
+    - |
+        !<tag:astropy.org:astropy/coordinates/angle-1.1.0>
+          unit: !unit/unit-1.0.0 deg
+          value: 10.0
+
+type: object
+properties:
+  value:
+    description: |
+      A vector of one or more values
+    anyOf:
+      - type: number
+      - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.1.0"
+  unit:
+    description: |
+      The unit corresponding to the values
+    $ref: "http://stsci.edu/schemas/asdf/unit/unit-1.0.0"
+required: [value, unit]
+...

--- a/resources/schemas/earthlocation-1.1.0.yaml
+++ b/resources/schemas/earthlocation-1.1.0.yaml
@@ -1,0 +1,34 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/earthlocation-1.1.0"
+
+title: |
+  Represents EarthLocation objects from astropy.
+
+description: |
+  Location on the Earth.
+
+type: object
+properties:
+  x:
+    description: |
+      X component of location in geocentric representation
+    $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+  y:
+    description: |
+      Y component of location in geocentric representation
+    $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+  z:
+    description: |
+      Z component of location in geocentric representation
+    $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+  ellipsoid:
+    description: |
+      Reference ellipsoid that is used when representing geodetic coordinates.
+    type: string
+    enum: [WGS84, GRS80, WGS72]
+
+required: [x, y, z]
+additionalProperties: False
+...

--- a/resources/schemas/frames/baseframe-1.1.0.yaml
+++ b/resources/schemas/frames/baseframe-1.1.0.yaml
@@ -1,0 +1,27 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/baseframe-1.1.0"
+
+title: |
+  Represents a coordinate frame object from astropy
+
+description: |
+  This schema is designed to be extended by other schemas to restrict the
+  allowable frame_attributes.
+
+type: object
+properties:
+  data:
+    description: |
+      The representation object holding any data associated with the frame.
+    $ref: "../representation-1.1.0"
+  frame_attributes:
+    description: |
+      Attributes on the coordinate frame.
+    type: object
+
+
+additionalProperties: false
+required: [frame_attributes]
+...

--- a/resources/schemas/frames/cirs-1.0.0.yaml
+++ b/resources/schemas/frames/cirs-1.0.0.yaml
@@ -9,12 +9,14 @@ title: |
 examples:
   -
     - A CIRS frame without data
+    - asdf-standard-1.5.0
     - |
         !<tag:astropy.org:astropy/coordinates/frames/cirs-1.0.0>
           frame_attributes:
             obstime: !time/time-1.1.0 {scale: tai, value: B1950.000}
   -
     - A CIRS frame with data
+    - asdf-standard-1.5.0
     - |
         !<tag:astropy.org:astropy/coordinates/frames/cirs-1.0.0>
           data: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>

--- a/resources/schemas/frames/cirs-1.1.0.yaml
+++ b/resources/schemas/frames/cirs-1.1.0.yaml
@@ -1,0 +1,44 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/cirs-1.1.0"
+
+title: |
+  Represents a CIRS coordinate object from astropy
+
+examples:
+  -
+    - A CIRS frame without data
+    - asdf-standard-1.6.0
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/cirs-1.1.0>
+          frame_attributes:
+            obstime: !time/time-1.2.0 {scale: tai, value: B1950.000}
+  -
+    - A CIRS frame with data
+    - asdf-standard-1.6.0
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/cirs-1.1.0>
+          data: !<tag:astropy.org:astropy/coordinates/representation-1.1.0>
+            components:
+              lat: !<tag:astropy.org:astropy/coordinates/latitude-1.1.0> {unit: !unit/unit-1.0.0 deg,
+                value: 10.0}
+              lon: !<tag:astropy.org:astropy/coordinates/longitude-1.1.0>
+                unit: !unit/unit-1.0.0 deg
+                value: 120.0
+                wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.1.0> {unit: !unit/unit-1.0.0 deg,
+                  value: 360.0}
+            type: UnitSphericalRepresentation
+          frame_attributes:
+            obstime: !time/time-1.2.0 {scale: tai, value: B1950.000}
+
+allOf:
+  - $ref: baseframe-1.1.0
+  - properties:
+      frame_attributes:
+        type: object
+        properties:
+          obstime:
+            $ref: "http://stsci.edu/schemas/asdf/time/time-1.2.0"
+        required: [obstime]
+...

--- a/resources/schemas/frames/fk4-1.0.0.yaml
+++ b/resources/schemas/frames/fk4-1.0.0.yaml
@@ -9,6 +9,7 @@ title: |
 examples:
   -
     - A FK4 frame without data
+    - asdf-standard-1.5.0
     - |
         !<tag:astropy.org:astropy/coordinates/frames/fk4-1.0.0>
           frame_attributes:
@@ -16,6 +17,7 @@ examples:
             obstime: !time/time-1.1.0 {scale: tai, value: B1950.000}
   -
     - A FK4 frame with data
+    - asdf-standard-1.5.0
     - |
         !<tag:astropy.org:astropy/coordinates/frames/fk4-1.0.0>
           data: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>

--- a/resources/schemas/frames/fk4-1.1.0.yaml
+++ b/resources/schemas/frames/fk4-1.1.0.yaml
@@ -1,0 +1,48 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/fk4-1.1.0"
+
+title: |
+  Represents a FK4 coordinate object from astropy
+
+examples:
+  -
+    - A FK4 frame without data
+    - asdf-standard-1.6.0
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/fk4-1.1.0>
+          frame_attributes:
+            equinox: !time/time-1.2.0 {scale: tai, value: B1950.000}
+            obstime: !time/time-1.2.0 {scale: tai, value: B1950.000}
+  -
+    - A FK4 frame with data
+    - asdf-standard-1.6.0
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/fk4-1.1.0>
+          data: !<tag:astropy.org:astropy/coordinates/representation-1.1.0>
+            components:
+              lat: !<tag:astropy.org:astropy/coordinates/latitude-1.1.0> {unit: !unit/unit-1.0.0 deg,
+                value: 10.0}
+              lon: !<tag:astropy.org:astropy/coordinates/longitude-1.1.0>
+                unit: !unit/unit-1.0.0 deg
+                value: 120.0
+                wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.1.0> {unit: !unit/unit-1.0.0 deg,
+                  value: 360.0}
+            type: UnitSphericalRepresentation
+          frame_attributes:
+            equinox: !time/time-1.2.0 {scale: tai, value: B1950.000}
+            obstime: !time/time-1.2.0 {scale: tai, value: B1950.000}
+
+allOf:
+  - $ref: baseframe-1.1.0
+  - properties:
+      frame_attributes:
+        type: object
+        properties:
+          equinox:
+            $ref: "http://stsci.edu/schemas/asdf/time/time-1.2.0"
+          obstime:
+            $ref: "http://stsci.edu/schemas/asdf/time/time-1.2.0"
+        required: [equinox]
+...

--- a/resources/schemas/frames/fk4noeterms-1.0.0.yaml
+++ b/resources/schemas/frames/fk4noeterms-1.0.0.yaml
@@ -9,6 +9,7 @@ title: |
 examples:
   -
     - A FK4NoETerms frame without data
+    - asdf-standard-1.5.0
     - |
         !<tag:astropy.org:astropy/coordinates/frames/fk4noeterms-1.0.0>
           frame_attributes:
@@ -16,6 +17,7 @@ examples:
             obstime: !time/time-1.1.0 {scale: tai, value: B1950.000}
   -
     - A FK4NoETerms frame with data
+    - asdf-standard-1.5.0
     - |
         !<tag:astropy.org:astropy/coordinates/frames/fk4noeterms-1.0.0>
           data: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>

--- a/resources/schemas/frames/fk4noeterms-1.1.0.yaml
+++ b/resources/schemas/frames/fk4noeterms-1.1.0.yaml
@@ -1,0 +1,48 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/fk4noeterms-1.1.0"
+
+title: |
+  Represents a FK4NoETerms coordinate object from astropy
+
+examples:
+  -
+    - A FK4NoETerms frame without data
+    - asdf-standard-1.6.0
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/fk4noeterms-1.1.0>
+          frame_attributes:
+            equinox: !time/time-1.2.0 {scale: tai, value: B1950.000}
+            obstime: !time/time-1.2.0 {scale: tai, value: B1950.000}
+  -
+    - A FK4NoETerms frame with data
+    - asdf-standard-1.6.0
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/fk4noeterms-1.1.0>
+          data: !<tag:astropy.org:astropy/coordinates/representation-1.1.0>
+            components:
+              lat: !<tag:astropy.org:astropy/coordinates/latitude-1.1.0> {unit: !unit/unit-1.0.0 deg,
+                value: 10.0}
+              lon: !<tag:astropy.org:astropy/coordinates/longitude-1.1.0>
+                unit: !unit/unit-1.0.0 deg
+                value: 120.0
+                wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.1.0> {unit: !unit/unit-1.0.0 deg,
+                  value: 360.0}
+            type: UnitSphericalRepresentation
+          frame_attributes:
+            equinox: !time/time-1.2.0 {scale: tai, value: B1950.000}
+            obstime: !time/time-1.2.0 {scale: tai, value: B1950.000}
+
+allOf:
+  - $ref: baseframe-1.1.0
+  - properties:
+      frame_attributes:
+        type: object
+        properties:
+          equinox:
+            $ref: "http://stsci.edu/schemas/asdf/time/time-1.2.0"
+          obstime:
+            $ref: "http://stsci.edu/schemas/asdf/time/time-1.2.0"
+        required: [equinox]
+...

--- a/resources/schemas/frames/fk5-1.1.0.yaml
+++ b/resources/schemas/frames/fk5-1.1.0.yaml
@@ -1,0 +1,42 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/fk5-1.1.0"
+
+title: |
+  Represents a FK5 coordinate object from astropy
+
+examples:
+  -
+    - A FK5 frame without data with a custom equinox
+    - asdf-standard-1.6.0
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/fk5-1.1.0>
+          frame_attributes: {equinox: !time/time-1.2.0 '2011-01-02 00:00:00.000'}
+  -
+    - A FK5 frame with data
+    - asdf-standard-1.6.0
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/fk5-1.1.0>
+          data: !<tag:astropy.org:astropy/coordinates/representation-1.1.0>
+            components:
+              lat: !<tag:astropy.org:astropy/coordinates/latitude-1.1.0> {unit: !unit/unit-1.0.0 deg,
+                value: 10.0}
+              lon: !<tag:astropy.org:astropy/coordinates/longitude-1.1.0>
+                unit: !unit/unit-1.0.0 deg
+                value: 120.0
+                wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.1.0> {unit: !unit/unit-1.0.0 deg,
+                  value: 360.0}
+            type: UnitSphericalRepresentation
+          frame_attributes: {equinox: !time/time-1.2.0 J2000.000}
+
+allOf:
+  - $ref: baseframe-1.1.0
+  - properties:
+      frame_attributes:
+        type: object
+        properties:
+          equinox:
+            $ref: "http://stsci.edu/schemas/asdf/time/time-1.2.0"
+        required: [equinox]
+...

--- a/resources/schemas/frames/galactic-1.1.0.yaml
+++ b/resources/schemas/frames/galactic-1.1.0.yaml
@@ -1,0 +1,38 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/galactic-1.1.0"
+
+title: |
+  Represents an Galactic coordinate object from astropy.
+
+examples:
+  -
+    - An Galactic frame without data
+    - asdf-standard-1.6.0
+    - |
+         !<tag:astropy.org:astropy/coordinates/frames/galactic-1.1.0>
+           frame_attributes: {}
+  -
+    - An Galactic frame with data
+    - asdf-standard-1.6.0
+    - |
+         !<tag:astropy.org:astropy/coordinates/frames/galactic-1.1.0>
+           data: !<tag:astropy.org:astropy/coordinates/representation-1.1.0>
+             components:
+               lat: !<tag:astropy.org:astropy/coordinates/latitude-1.1.0> {unit: !unit/unit-1.0.0 deg,
+                 value: 2.0}
+               lon: !<tag:astropy.org:astropy/coordinates/longitude-1.1.0>
+                 unit: !unit/unit-1.0.0 deg
+                 value: 1.0
+                 wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.1.0> {unit: !unit/unit-1.0.0 deg,
+                   value: 360.0}
+             type: UnitSphericalRepresentation
+           frame_attributes: {}
+
+
+
+
+allOf:
+  - $ref: baseframe-1.1.0
+...

--- a/resources/schemas/frames/galactocentric-1.0.0.yaml
+++ b/resources/schemas/frames/galactocentric-1.0.0.yaml
@@ -9,6 +9,7 @@ title: |
 examples:
   -
     - A Galactocentric frame without data
+    - asdf-standard-1.5.0
     - |
         !<tag:astropy.org:astropy/coordinates/frames/galactocentric-1.0.0>
           frame_attributes:

--- a/resources/schemas/frames/galactocentric-1.1.0.yaml
+++ b/resources/schemas/frames/galactocentric-1.1.0.yaml
@@ -1,0 +1,56 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/galactocentric-1.1.0"
+
+title: |
+  Represents an galactocentric coordinate object from astropy
+
+examples:
+  -
+    - A Galactocentric frame without data
+    - asdf-standard-1.6.0
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/galactocentric-1.1.0>
+          frame_attributes:
+            galcen_coord: !<tag:astropy.org:astropy/coordinates/frames/icrs-1.1.0>
+              data: !<tag:astropy.org:astropy/coordinates/representation-1.1.0>
+                components:
+                  lat: !<tag:astropy.org:astropy/coordinates/latitude-1.1.0> {unit: !unit/unit-1.0.0 deg,
+                    value: -28.936175}
+                  lon: !<tag:astropy.org:astropy/coordinates/longitude-1.1.0>
+                    unit: !unit/unit-1.0.0 deg
+                    value: 266.4051
+                    wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.1.0> {unit: !unit/unit-1.0.0 deg,
+                      value: 360.0}
+                type: UnitSphericalRepresentation
+              frame_attributes: {}
+            galcen_distance: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 kpc, value: 8.3}
+            galcen_v_sun: !<tag:astropy.org:astropy/coordinates/representation-1.1.0>
+              components:
+                d_x: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 km s-1, value: 11.1}
+                d_y: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 km s-1, value: 232.24}
+                d_z: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 km s-1, value: 7.25}
+              type: CartesianDifferential
+            roll: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 deg, value: 0.0}
+            z_sun: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 pc, value: 27.0}
+
+allOf:
+  - $ref: baseframe-1.1.0
+  - properties:
+      frame_attributes:
+        type: object
+        properties:
+          galacen_coord:
+            $ref: "icrs-1.2.0"
+          galcen_distance:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+          galcen_v_sun:
+            $ref: "../representation-1.1.0"
+          z_sun:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+          roll:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+
+        required: [galcen_coord, galcen_distance, galcen_v_sun, z_sun, roll]
+...

--- a/resources/schemas/frames/gcrs-1.0.0.yaml
+++ b/resources/schemas/frames/gcrs-1.0.0.yaml
@@ -9,6 +9,7 @@ title: |
 examples:
   -
     - A GCRS frame without data
+    - asdf-standard-1.5.0
     - |
         !<tag:astropy.org:astropy/coordinates/frames/gcrs-1.0.0>
             frame_attributes:
@@ -27,6 +28,7 @@ examples:
               obstime: !time/time-1.1.0 J2000.000
   -
     - A GCRS frame with data
+    - asdf-standard-1.5.0
     - |
         !<tag:astropy.org:astropy/coordinates/frames/gcrs-1.0.0>
           data: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>

--- a/resources/schemas/frames/gcrs-1.1.0.yaml
+++ b/resources/schemas/frames/gcrs-1.1.0.yaml
@@ -1,0 +1,71 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/gcrs-1.1.0"
+
+title: |
+  Represents a GCRS coordinate object from astropy
+
+examples:
+  -
+    - A GCRS frame without data
+    - asdf-standard-1.6.0
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/gcrs-1.1.0>
+            frame_attributes:
+              obsgeoloc: !<tag:astropy.org:astropy/coordinates/representation-1.1.0>
+                components:
+                  x: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+                  y: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+                  z: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+                type: CartesianRepresentation
+              obsgeovel: !<tag:astropy.org:astropy/coordinates/representation-1.1.0>
+                components:
+                  x: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+                  y: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+                  z: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+                type: CartesianRepresentation
+              obstime: !time/time-1.2.0 J2000.000
+  -
+    - A GCRS frame with data
+    - asdf-standard-1.6.0
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/gcrs-1.1.0>
+          data: !<tag:astropy.org:astropy/coordinates/representation-1.1.0>
+            components:
+              lat: !<tag:astropy.org:astropy/coordinates/latitude-1.1.0> {unit: !unit/unit-1.0.0 deg,
+                value: 2.0}
+              lon: !<tag:astropy.org:astropy/coordinates/longitude-1.1.0>
+                unit: !unit/unit-1.0.0 deg
+                value: 1.0
+                wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.1.0> {unit: !unit/unit-1.0.0 deg,
+                  value: 360.0}
+            type: UnitSphericalRepresentation
+          frame_attributes:
+            obsgeoloc: !<tag:astropy.org:astropy/coordinates/representation-1.1.0>
+              components:
+                x: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+                y: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+                z: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+              type: CartesianRepresentation
+            obsgeovel: !<tag:astropy.org:astropy/coordinates/representation-1.1.0>
+              components:
+                x: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+                y: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+                z: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+              type: CartesianRepresentation
+            obstime: !time/time-1.2.0 J2000.000
+
+allOf:
+  - $ref: baseframe-1.1.0
+  - properties:
+      frame_attributes:
+        type: object
+        properties:
+          obstime:
+            $ref: "http://stsci.edu/schemas/asdf/time/time-1.2.0"
+          obsgeoloc:
+            $ref: "../representation-1.1.0"
+          obsgeovel:
+            $ref: "../representation-1.1.0"
+...

--- a/resources/schemas/frames/icrs-1.2.0.yaml
+++ b/resources/schemas/frames/icrs-1.2.0.yaml
@@ -1,0 +1,37 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/icrs-1.2.0"
+
+title: |
+  Represents an ICRS coordinate object from astropy.
+
+examples:
+  -
+    - An ICRS frame without data
+    - asdf-standard-1.6.0
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/icrs-1.2.0>
+          frame_attributes: {}
+  -
+    - An ICRS frame with data
+    - asdf-standard-1.6.0
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/icrs-1.2.0>
+          data: !<tag:astropy.org:astropy/coordinates/representation-1.1.0>
+            components:
+              lat: !<tag:astropy.org:astropy/coordinates/latitude-1.1.0> {unit: !unit/unit-1.0.0 deg,
+                value: 10.0}
+              lon: !<tag:astropy.org:astropy/coordinates/longitude-1.1.0>
+                unit: !unit/unit-1.0.0 deg
+                value: 120.0
+                wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.1.0> {unit: !unit/unit-1.0.0 deg,
+                  value: 360.0}
+            type: UnitSphericalRepresentation
+          frame_attributes: {}
+
+
+
+allOf:
+  - $ref: baseframe-1.1.0
+...

--- a/resources/schemas/frames/itrs-1.0.0.yaml
+++ b/resources/schemas/frames/itrs-1.0.0.yaml
@@ -9,12 +9,14 @@ title: |
 examples:
   -
     - A ITRS frame without data
+    - asdf-standard-1.5.0
     - |
         !<tag:astropy.org:astropy/coordinates/frames/itrs-1.0.0>
           frame_attributes:
             obstime: !time/time-1.1.0 {scale: tai, value: B1950.000}
   -
     - A ITRS frame with data
+    - asdf-standard-1.5.0
     - |
         !<tag:astropy.org:astropy/coordinates/frames/itrs-1.0.0>
           data: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>

--- a/resources/schemas/frames/itrs-1.1.0.yaml
+++ b/resources/schemas/frames/itrs-1.1.0.yaml
@@ -1,0 +1,44 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/itrs-1.1.0"
+
+title: |
+  Represents a ITRS coordinate object from astropy
+
+examples:
+  -
+    - A ITRS frame without data
+    - asdf-standard-1.6.0
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/itrs-1.1.0>
+          frame_attributes:
+            obstime: !time/time-1.2.0 {scale: tai, value: B1950.000}
+  -
+    - A ITRS frame with data
+    - asdf-standard-1.6.0
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/itrs-1.1.0>
+          data: !<tag:astropy.org:astropy/coordinates/representation-1.1.0>
+            components:
+              lat: !<tag:astropy.org:astropy/coordinates/latitude-1.1.0> {unit: !unit/unit-1.0.0 deg,
+                value: 10.0}
+              lon: !<tag:astropy.org:astropy/coordinates/longitude-1.1.0>
+                unit: !unit/unit-1.0.0 deg
+                value: 120.0
+                wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.1.0> {unit: !unit/unit-1.0.0 deg,
+                  value: 360.0}
+            type: UnitSphericalRepresentation
+          frame_attributes:
+            obstime: !time/time-1.2.0 {scale: tai, value: B1950.000}
+
+allOf:
+  - $ref: baseframe-1.1.0
+  - properties:
+      frame_attributes:
+        type: object
+        properties:
+          obstime:
+            $ref: "http://stsci.edu/schemas/asdf/time/time-1.2.0"
+        required: [obstime]
+...

--- a/resources/schemas/frames/precessedgeocentric-1.0.0.yaml
+++ b/resources/schemas/frames/precessedgeocentric-1.0.0.yaml
@@ -9,6 +9,7 @@ title: |
 examples:
   -
     - A PrecessedGeocentric frame without data
+    - asdf-standard-1.5.0
     - |
         !<tag:astropy.org:astropy/coordinates/frames/precessedgeocentric-1.0.0>
           frame_attributes:
@@ -28,6 +29,7 @@ examples:
             obstime: !time/time-1.1.0 J2000.000
   -
     - A PrecessedGeocentric frame with data
+    - asdf-standard-1.5.0
     - |
         !<tag:astropy.org:astropy/coordinates/frames/precessedgeocentric-1.0.0>
             data: !<tag:astropy.org:astropy/coordinates/representation-1.0.0>

--- a/resources/schemas/frames/precessedgeocentric-1.1.0.yaml
+++ b/resources/schemas/frames/precessedgeocentric-1.1.0.yaml
@@ -1,0 +1,75 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/precessedgeocentric-1.1.0"
+
+title: |
+  Represents a PrecessedGeocentric coordinate object from astropy
+
+examples:
+  -
+    - A PrecessedGeocentric frame without data
+    - asdf-standard-1.6.0
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/precessedgeocentric-1.1.0>
+          frame_attributes:
+            equinox: !time/time-1.2.0 J2000.000
+            obsgeoloc: !<tag:astropy.org:astropy/coordinates/representation-1.1.0>
+              components:
+                x: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+                y: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+                z: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+              type: CartesianRepresentation
+            obsgeovel: !<tag:astropy.org:astropy/coordinates/representation-1.1.0>
+              components:
+                x: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+                y: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+                z: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+              type: CartesianRepresentation
+            obstime: !time/time-1.2.0 J2000.000
+  -
+    - A PrecessedGeocentric frame with data
+    - asdf-standard-1.6.0
+    - |
+        !<tag:astropy.org:astropy/coordinates/frames/precessedgeocentric-1.1.0>
+            data: !<tag:astropy.org:astropy/coordinates/representation-1.1.0>
+              components:
+                lat: !<tag:astropy.org:astropy/coordinates/latitude-1.1.0> {unit: !unit/unit-1.0.0 deg,
+                  value: 1.0}
+                lon: !<tag:astropy.org:astropy/coordinates/longitude-1.1.0>
+                  unit: !unit/unit-1.0.0 deg
+                  value: 1.0
+                  wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.1.0> {unit: !unit/unit-1.0.0 deg,
+                    value: 360.0}
+              type: UnitSphericalRepresentation
+            frame_attributes:
+              equinox: !time/time-1.2.0 J2000.000
+              obsgeoloc: !<tag:astropy.org:astropy/coordinates/representation-1.1.0>
+                components:
+                  x: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+                  y: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+                  z: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m, value: 0.0}
+                type: CartesianRepresentation
+              obsgeovel: !<tag:astropy.org:astropy/coordinates/representation-1.1.0>
+                components:
+                  x: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+                  y: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+                  z: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 m s-1, value: 0.0}
+                type: CartesianRepresentation
+              obstime: !time/time-1.2.0 J2000.000
+
+allOf:
+  - $ref: baseframe-1.1.0
+  - properties:
+      frame_attributes:
+        type: object
+        properties:
+          equinox:
+            $ref: "http://stsci.edu/schemas/asdf/time/time-1.2.0"
+          obstime:
+            $ref: "http://stsci.edu/schemas/asdf/time/time-1.2.0"
+          obsgeoloc:
+            $ref: "../representation-1.1.0"
+          obsgeovel:
+            $ref: "../representation-1.1.0"
+...

--- a/resources/schemas/latitude-1.1.0.yaml
+++ b/resources/schemas/latitude-1.1.0.yaml
@@ -1,0 +1,34 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/latitude-1.1.0"
+
+title: |
+  Represents latitude-like angles.
+
+description: |
+  Represents latitude-like angle(s) which must be in the range -90 to +90 deg.
+
+examples:
+  -
+    - A Latitude object in Degrees
+    - asdf-standard-1.6.0
+    - |
+        !<tag:astropy.org:astropy/coordinates/latitude-1.1.0>
+          unit: !unit/unit-1.0.0 deg
+          value: 10.0
+
+type: object
+properties:
+  value:
+    description: |
+      A vector of one or more values
+    anyOf:
+      - type: number
+      - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.1.0"
+  unit:
+    description: |
+      The unit corresponding to the values
+    $ref: "http://stsci.edu/schemas/asdf/unit/unit-1.0.0"
+required: [value, unit]
+...

--- a/resources/schemas/longitude-1.1.0.yaml
+++ b/resources/schemas/longitude-1.1.0.yaml
@@ -1,0 +1,42 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/longitude-1.1.0"
+
+title: |
+  Represents longitude-like angles.
+
+description: |
+    Longitude-like angle(s) which are wrapped within a contiguous 360 degree range.
+
+examples:
+  -
+    - A Longitude object in Degrees
+    - asdf-standard-1.6.0
+    - |
+        !<tag:astropy.org:astropy/coordinates/longitude-1.1.0>
+          unit: !unit/unit-1.0.0 deg
+          value: 10.0
+          wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.1.0>
+            unit: !unit/unit-1.0.0 deg
+            value: 180.0
+
+type: object
+properties:
+  value:
+    description: |
+      A vector of one or more values
+    anyOf:
+      - type: number
+      - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.1.0"
+  unit:
+    description: |
+      The unit corresponding to the values
+    $ref: "http://stsci.edu/schemas/asdf/unit/unit-1.0.0"
+  wrap_angle:
+    description: |
+      Angle at which to wrap back to ``wrap_angle - 360 deg``.
+    $ref: "angle-1.1.0"
+
+required: [value, unit, wrap_angle]
+...

--- a/resources/schemas/representation-1.0.0.yaml
+++ b/resources/schemas/representation-1.0.0.yaml
@@ -12,6 +12,7 @@ description: |
 examples:
   -
     - A SphericalRepresentation
+    - asdf-standard-1.5.0
     - |
         !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
           components:
@@ -26,6 +27,7 @@ examples:
           type: SphericalRepresentation
   -
     - A CartesianDifferential
+    - asdf-standard-1.5.0
     - |
         !<tag:astropy.org:astropy/coordinates/representation-1.0.0>
           components:

--- a/resources/schemas/representation-1.1.0.yaml
+++ b/resources/schemas/representation-1.1.0.yaml
@@ -1,0 +1,208 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/representation-1.1.0"
+
+title: |
+  Representation of points or differentials in two or three dimensional space.
+
+description: |
+  Representation of points or differentials in two or three dimensional space.
+
+examples:
+  -
+    - A SphericalRepresentation
+    - asdf-standard-1.6.0
+    - |
+        !<tag:astropy.org:astropy/coordinates/representation-1.1.0>
+          components:
+            distance: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 AU, value: 1.0}
+            lat: !<tag:astropy.org:astropy/coordinates/latitude-1.1.0> {unit: !unit/unit-1.0.0 deg,
+              value: 10.0}
+            lon: !<tag:astropy.org:astropy/coordinates/longitude-1.1.0>
+              unit: !unit/unit-1.0.0 deg
+              value: 10.0
+              wrap_angle: !<tag:astropy.org:astropy/coordinates/angle-1.1.0> {unit: !unit/unit-1.0.0 deg,
+                value: 360.0}
+          type: SphericalRepresentation
+  -
+    - A CartesianDifferential
+    - asdf-standard-1.6.0
+    - |
+        !<tag:astropy.org:astropy/coordinates/representation-1.1.0>
+          components:
+            d_x: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 km s-1, value: 100.0}
+            d_y: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 km s-1, value: 200.0}
+            d_z: !unit/quantity-1.2.0 {unit: !unit/unit-1.0.0 km s-1, value: 3141.0}
+          type: CartesianDifferential
+
+type: object
+properties:
+  type:
+    type: string
+    enum:
+      - CartesianRepresentation
+      - SphericalRepresentation
+      - UnitSphericalRepresentation
+      - RadialRepresentation
+      - PhysicsSphericalRepresentation
+      - CylindricalRepresentation
+      - CartesianDifferential
+      - SphericalDifferential
+      - UnitSphericalCosLatDifferential
+      - UnitSphericalDifferential
+      - SphericalCosLatDifferential
+      - RadialDifferential
+      - PhysicsSphericalDifferential
+      - CylindricalDifferential
+
+  components:
+    anyOf:
+      # CartesianRepresentation
+      - type: object
+        properties:
+          x:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+          y:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+          z:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+
+      # SphericalRepresentation
+      - type: object
+        properties:
+          lat:
+            $ref: "latitude-1.1.0"
+          lon:
+            $ref: "longitude-1.1.0"
+          distance:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+
+      # UnitSphericalRepresentation
+      - type: object
+        properties:
+          lat:
+            $ref: "latitude-1.1.0"
+          lon:
+            $ref: "longitude-1.1.0"
+
+      # RadialRepresentation
+      - type: object
+        properties:
+          distance:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+
+      # PhysicsSphericalRepresentation
+      - type: object
+        properties:
+          phi:
+            $ref: "angle-1.1.0"
+          theta:
+            $ref: "angle-1.1.0"
+          r:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+
+      # CylindricalRepresentation
+      - type: object
+        properties:
+          rho:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+          phi:
+            $ref: "angle-1.1.0"
+          z:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+
+      # CartesianDifferential
+      - type: object
+        properties:
+          d_x:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+          d_y:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+          d_z:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+
+      # SphericalDifferential
+      - type: object
+        properties:
+          d_lon:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+          d_lat:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+          d_distance:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+
+      # UnitSphericalCosLatDifferential
+      - type: object
+        properties:
+          d_lon_coslat:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+          d_lat:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+
+      # UnitSphericalDifferential
+      - type: object
+        properties:
+          d_lon:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+          d_lat:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+
+      # SphericalCosLatDifferential
+      - type: object
+        properties:
+          d_lon_coslat:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+          d_lat:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+          d_distance:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+
+      # SphericalDifferential
+      - type: object
+        properties:
+          d_lon:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+          d_lat:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+          d_distance:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+
+      # RadialDifferential
+      - type: object
+        properties:
+          d_phi:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+          d_theta:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+          d_r:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+
+      # PhysicsSphericalDifferential
+      - type: object
+        properties:
+          d_phi:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+          d_theta:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+          d_r:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+
+      # RadialDifferential
+      - type: object
+        properties:
+          d_distance:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+
+      # CylindricalDifferential
+      - type: object
+        properties:
+          d_rho:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+          d_phi:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+          d_z:
+            $ref: "http://stsci.edu/schemas/asdf/unit/quantity-1.2.0"
+
+required: [type, components]
+...

--- a/resources/schemas/spectralcoord-1.1.0.yaml
+++ b/resources/schemas/spectralcoord-1.1.0.yaml
@@ -1,0 +1,30 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coordinates/spectralcoord-1.1.0"
+
+title: >
+  Represents a SpectralCoord object from astropy
+
+type: object
+properties:
+  value:
+    description: |
+      A vector of one or more values
+    anyOf:
+      - type: number
+      - $ref: "http://stsci.edu/schemas/asdf/core/ndarray-1.1.0"
+  unit:
+    description: |
+      The unit corresponding to the values
+    $ref: "http://stsci.edu/schemas/asdf/unit/unit-1.0.0"
+  observer:
+    description: |
+      The observer frame for this coordinate
+    $ref: "http://astropy.org/schemas/astropy/coordinates/frames/baseframe-1.1.0"
+  target:
+    description: |
+      The target frame for this coordinate
+    $ref: "http://astropy.org/schemas/astropy/coordinates/frames/baseframe-1.1.0"
+required: [value, unit]
+...

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist= py39,twine,black,flake8,bandit
+envlist= py39,py310,py311,py312,twine,black,flake8,bandit
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
~As several schemas reference `ndarray-1.1.0` (which is not yet in a released version of ASDF standard 1.6.0) this PR temporarily adds a dev requirement for asdf-standard (which can be removed after https://github.com/asdf-format/asdf-standard/pull/422 is merged and released).~ EDIT: asdf-standard 1.1.0 was released