### PR TITLE
docs/latex-logo-path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ------------------
 
 - Changes documentation configuration settings to make this consistent with other asdf-related projects [#61]
+- Fix typo in latex logo path [#62]
 
 0.3.0 (2024-03-09)
 ------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -135,7 +135,7 @@ graphviz_dot_args = [
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [("index", project + ".tex", project + " Documentation", author, "manual")]
 
-latex_logo = "_static/images/logo-light.png"
+latex_logo = "_static/images/logo-light-mode.png"
 
 
 # -- Options for manual page output --------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ configuration = conf["project"]
 
 project = configuration["name"]
 author = f"{configuration['authors'][0]['name']} <{configuration['authors'][0]['email']}>"
-copyright = f"{datetime.datetime.now().year}, {configuration['authors'][0]}"
+copyright = f"{datetime.datetime.now().year}, {author}"
 
 release = get_distribution(configuration["name"]).version
 version = ".".join(release.split(".")[:2])


### PR DESCRIPTION
- fix typo in latex logo filename so that RTD docs build correctly
- fix copyright text in footer ( Display `The ASDF Developers <help@stsci.edu>` instead of `{'name': 'The ASDF Developers', 'email': 'help@stsci.edu'}`)