### PR TITLE
prefer tomllib from the Standard Library when available

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,9 +3,14 @@ import os
 import sys
 from pathlib import Path
 
+try:
+    # Added in Python 3.11
+    import tomllib
+except ImportError
+    import tomli as tomllib
+
 # Ensure documentation examples are determinstically random.
 import numpy
-import tomli
 from pkg_resources import get_distribution
 
 try:
@@ -21,7 +26,7 @@ except ImportError:
 
 # Get configuration information from `pyproject.toml`
 with open(Path(__file__).parent.parent / "pyproject.toml", "rb") as configuration_file:
-    conf = tomli.load(configuration_file)
+    conf = tomllib.load(configuration_file)
 configuration = conf["project"]
 
 # -- General configuration ----------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dynamic = ['version']
 
 [project.optional-dependencies]
 docs = [
-    'tomli',
+    'tomli; python_version < "3.11"',
     'sphinx',
     'sphinx-asdf >= 0.1.3',
     'sphinx-astropy',


### PR DESCRIPTION
`tomli` has been accepted in the standard library as `tomllib

https://docs.python.org/3/library/tomllib.html