### PR TITLE
use new pytest asdf plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ docs = [
 ]
 test = [
     'pytest',
+    'pytest-asdf-plugin',
     'asdf-astropy >= 0.2.0'
 ]
 


### PR DESCRIPTION
See https://github.com/asdf-format/asdf-standard/pull/478 for details

Update test requirements to use new pytest-asdf-plugin.

On main 241 tests passed:
https://github.com/asdf-format/asdf-coordinates-schemas/actions/runs/17036304654/job/48289503487#step:5:91

With this PR 241 tests passed:
https://github.com/asdf-format/asdf-coordinates-schemas/actions/runs/17047859333/job/48328133281?pr=71#step:5:93
