### PR TITLE
Update RTD build OS from Ubuntu 20.04 to 24.04

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   apt_packages:
     - graphviz
   tools:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,16 @@ from pathlib import Path
 # Ensure documentation examples are deterministically random.
 import numpy
 import tomli
-from pkg_resources import get_distribution
+
+# The standard library importlib.metadata returns duplicate entrypoints
+# for all python versions up to and including 3.11
+# https://github.com/python/importlib_metadata/issues/410#issuecomment-1304258228
+# see PR https://github.com/asdf-format/asdf/pull/1260
+# see issue https://github.com/asdf-format/asdf/issues/1254
+if sys.version_info >= (3, 12):
+    from importlib.metadata import distribution
+else:
+    from importlib_metadata import distribution
 
 try:
     numpy.random.seed(int(os.environ["SOURCE_DATE_EPOCH"]))
@@ -30,7 +39,7 @@ project = configuration["name"]
 author = configuration["authors"][0]["name"]
 copyright = f"{datetime.datetime.now().year}, {author}"
 
-release = get_distribution(configuration["name"]).version
+release = distribution(configuration["name"]).version
 # The short X.Y version
 version = ".".join(release.split(".")[:2])
 


### PR DESCRIPTION
## Changelog
* Updated RTD build OS from Ubuntu 20.04 to 24.04
* Updated `docs/conf.py` to use `importlib_metadata` instead of `pkg_resources`